### PR TITLE
ASCP Protocol Decode and Encode Routine for gopacket library

### DIFF
--- a/layers/drcp.go
+++ b/layers/drcp.go
@@ -1654,27 +1654,62 @@ func (ascp *ASPDU) serializeTerminator(b gopacket.SerializeBuffer) error {
 	return nil
 }
 
+// Get Reserved Attribute
 func GetMacAttrReserved(fdbAttr uint16) uint16 {
 
-	return ((fdbAttr & fdbAttrReserved) >> 15)
+	return ((fdbAttr & fdbAttrReserved) >> 14)
 
 }
 
+// Get State Attribute
 func GetMacAttrState(fdbAttr uint16) uint16 {
 
-	return ((fdbAttr & fdbAttrState) >> 14)
+	return ((fdbAttr & fdbAttrState) >> 13)
 
 }
 
+// Get Port Type Attribute
 func GetMacAttrPortType(fdbAttr uint16) uint16 {
 
-	return ((fdbAttr & fdbAttrPortType) >> 13)
+	return ((fdbAttr & fdbAttrPortType) >> 12)
 
 }
 
+// Get Vid Attribute
 func GetMacAttrVid(fdbAttr uint16) uint16 {
 
 	return (fdbAttr & fdbAttrVid)
+
+}
+
+// Set Reserved Attribute
+func SetMacAttrReserved(fdbAttr uint16, rsvd uint16) uint16 {
+
+	return (fdbAttr | (rsvd << 14))
+
+}
+
+// Set State Attribute
+func SetMacAttrState(fdbAttr uint16, set uint16) uint16 {
+
+   if (set==1) {
+	return (fdbAttr | (set << 13))
+   }
+
+   return fdbAttr
+}
+
+// Set Port Attribute
+func SetMacAttrPortType(fdbAttr uint16, set uint16) uint16 {
+
+	return (fdbAttr | (set << 12))
+
+}
+
+// Set Vid Attribute
+func SetMacAttrVid(fdbAttr uint16, vid uint16) uint16 {
+
+	return (fdbAttr | vid)
 
 }
 

--- a/layers/drcp.go
+++ b/layers/drcp.go
@@ -268,6 +268,32 @@ func (l *DRCP) LayerType() gopacket.LayerType {
 	return LayerTypeDRCP
 }
 
+type DrcpProtocol struct {
+	BaseLayer
+	SubType DrcpProtocolType
+}
+
+// LayerType returns LayerTypeDrcpProtocol
+func (d *DrcpProtocol) LayerType() gopacket.LayerType { return LayerTypeDRCPProtocol }
+
+
+// decodeDRCPProtocol
+func decodeDRCPProtocol(data []byte, p gopacket.PacketBuilder) error {
+	drcp := &DrcpProtocol{
+		BaseLayer: BaseLayer{data[:1], data[1:]},
+		SubType:   DrcpProtocolType(data[0]),
+	}
+
+	if drcp.SubType !=  DrcpProtocolTypeDRCP &&
+		drcp.SubType !=  DrcpProtocolTypeASCP {
+		return fmt.Errorf("DRCP Protocol has invalid type")
+	}
+
+	p.AddLayer(drcp)
+	return p.NextDecoder(drcp.SubType)
+}
+
+
 // TOOD Function only decodes Version 1
 func decodeDRCP(data []byte, p gopacket.PacketBuilder) error {
 	drcp := &DRCP{BaseLayer: BaseLayer{Contents: data}}

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -82,6 +82,14 @@ const (
 	SlowProtocolTypeOSSP SlowProtocolType = 10
 )
 
+type DrcpProtocolType byte
+
+// DRCP protocol has 2 type - DRCP and ASCP subtypes
+const (
+DrcpProtocolTypeDRCP    DrcpProtocolType = 1
+DrcpProtocolTypeASCP    DrcpProtocolType = 2
+)
+
 // IPProtocol is an enumeration of IP protocol values, and acts as a decoder
 // for any type it supports.
 type IPProtocol uint8
@@ -308,6 +316,7 @@ var (
 	Dot11TypeMetadata        [256]EnumMetadata
 	USBTypeMetadata          [256]EnumMetadata
 	SlowProtocolTypeMetadata [256]EnumMetadata
+	DrcpSubTypeMetadata      [256]EnumMetadata
 )
 
 func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
@@ -327,6 +336,15 @@ func (a SlowProtocolType) String() string {
 }
 func (a SlowProtocolType) LayerType() gopacket.LayerType {
 	return SlowProtocolTypeMetadata[a].LayerType
+}
+func (a DrcpProtocolType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return DrcpSubTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a DrcpProtocolType) String() string {
+	return DrcpSubTypeMetadata[a].Name
+}
+func (a DrcpProtocolType) LayerType() gopacket.LayerType {
+	return DrcpSubTypeMetadata[a].LayerType
 }
 func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
@@ -471,7 +489,7 @@ func init() {
 	EthernetTypeMetadata[EthernetTypeQinQ] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot1Q), Name: "Dot1Q", LayerType: LayerTypeDot1Q}
 	EthernetTypeMetadata[EthernetTypeTransparentEthernetBridging] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeEthernet), Name: "TransparentEthernetBridging", LayerType: LayerTypeEthernet}
 	EthernetTypeMetadata[EthernetTypeSlowProtocol] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeSlowProtocol), Name: "SlowProtocol", LayerType: LayerTypeSlowProtocol}
-	EthernetTypeMetadata[EthernetTypeDRCP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDRCP), Name: "DistributedRelayControlProtocol", LayerType: LayerTypeDRCP}
+	EthernetTypeMetadata[EthernetTypeDRCP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDRCPProtocol), Name: "DistributedRelayControlProtocol", LayerType: LayerTypeDRCPProtocol}
 
 	IPProtocolMetadata[IPProtocolIPv4] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4), Name: "IPv4", LayerType: LayerTypeIPv4}
 	IPProtocolMetadata[IPProtocolTCP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeTCP), Name: "TCP", LayerType: LayerTypeTCP}
@@ -586,4 +604,7 @@ func init() {
 	// TODO part of slow protocol but not implemented
 	//SlowProtocolTypeMetadata[EthernetSlowProtocolTypeLACP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeOAM), Name: "LACP", LayerType: LayerTypeOAM}
 	//SlowProtocolTypeMetadata[EthernetSlowProtocolTypeLACP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeOSSP), Name: "LACP", LayerType: LayerTypeOSSP}
+
+	DrcpSubTypeMetadata[DrcpProtocolTypeDRCP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDRCP), Name: "DistributedRelayControlProtocol", LayerType: LayerTypeDRCP}
+	DrcpSubTypeMetadata[DrcpProtocolTypeASCP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeASCP), Name: "AddressSyncControlProtocol", LayerType: LayerTypeASCP}
 }

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -126,6 +126,7 @@ var (
 	LayerTypePVST  = gopacket.RegisterLayerType(122, gopacket.LayerTypeMetadata{"PVST", gopacket.DecodeFunc(decodePVST)})
 	LayerTypeVxlan = gopacket.RegisterLayerType(123, gopacket.LayerTypeMetadata{"VXLAN", gopacket.DecodeFunc(decodeVxlan)})
 	LayerTypeDRCP  = gopacket.RegisterLayerType(124, gopacket.LayerTypeMetadata{"DRCP", gopacket.DecodeFunc(decodeDRCP)})
+    LayerTypeASCP  = gopacket.RegisterLayerType(125, gopacket.LayerTypeMetadata{"ASCP", gopacket.DecodeFunc(decodeASCP)})
 )
 
 var (

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -125,8 +125,9 @@ var (
 	LayerTypeBPDU  = gopacket.RegisterLayerType(121, gopacket.LayerTypeMetadata{"STP", gopacket.DecodeFunc(decodeBPDU)})
 	LayerTypePVST  = gopacket.RegisterLayerType(122, gopacket.LayerTypeMetadata{"PVST", gopacket.DecodeFunc(decodePVST)})
 	LayerTypeVxlan = gopacket.RegisterLayerType(123, gopacket.LayerTypeMetadata{"VXLAN", gopacket.DecodeFunc(decodeVxlan)})
-	LayerTypeDRCP  = gopacket.RegisterLayerType(124, gopacket.LayerTypeMetadata{"DRCP", gopacket.DecodeFunc(decodeDRCP)})
-    LayerTypeASCP  = gopacket.RegisterLayerType(125, gopacket.LayerTypeMetadata{"ASCP", gopacket.DecodeFunc(decodeASCP)})
+	LayerTypeDRCPProtocol                = gopacket.RegisterLayerType(124, gopacket.LayerTypeMetadata{"DRCP Protocol", gopacket.DecodeFunc(decodeDRCPProtocol)})
+	LayerTypeDRCP  = gopacket.RegisterLayerType(125, gopacket.LayerTypeMetadata{"DRCP", gopacket.DecodeFunc(decodeDRCP)})
+    LayerTypeASCP  = gopacket.RegisterLayerType(126, gopacket.LayerTypeMetadata{"ASCP", gopacket.DecodeFunc(decodeASCP)})
 )
 
 var (


### PR DESCRIPTION
[802.1AX-2014.pdf](https://github.com/SnapRoute/gopacket/files/1100169/802.1AX-2014.pdf)

+   Annex G IEEE Std 802.1AX-2014
+	 Fig G.2 - ASPDU Structure
+   +----------------------------+
+   | SubType = AS               |  1 octet
+   +----------------------------+
+   | Version Number             |  1 octet
+   +----------------------------+
+   | MAC Address 	            |  X octets
+   | Synchronization TLVs		|
+   +----------------------------+
+   | TLV_type = Terminator      |  1 octet
+   +----------------------------+
+   | Terminator_Length = 0      |  1 octet
+   +----------------------------+
+*/

+   Annex G IEEE Std 802.1AX-2014
+	 Fig G.3 Address Sync Tlv
+	 Fig G.4 Address Req Tlv
+   +--------------------------------------------+
+   | TLV_type = Address Sync/Req  |  1 octet    |
+   +--------------------------------------------+
+   | Length = Nx8 	  	          |	 1 octet    |
+   +--------------------------------------------+
+   | Fdb Entry 1		 		  |  8 Octets   |
+   +--------------------------------------------+
+   | Fdb Entry 2				  |  8 Octets   |
+   +--------------------------------------------+
+   | Fdb Entry 3		 		  |  8 Octets   |
+   +--------------------------------------------+
+   |											|
+   |										    |
+   |											|
+   |											|
+   +--------------------------------------------+
+   | Fdb Entry N		 		  |  8 Octets   |
+   +--------------------------------------------+
+*/
